### PR TITLE
Add stonecutting recipes for stone blocks

### DIFF
--- a/src/generated/resources/data/betterendforge/advancements/recipes/betterendforge/flavolite_bricks_from_flavolite_stonecutting.json
+++ b/src/generated/resources/data/betterendforge/advancements/recipes/betterendforge/flavolite_bricks_from_flavolite_stonecutting.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "betterendforge:flavolite_bricks_from_flavolite_stonecutting"
+    ]
+  },
+  "criteria": {
+    "has_stone": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "betterendforge:flavolite"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "betterendforge:flavolite_bricks_from_flavolite_stonecutting"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_stone",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/generated/resources/data/betterendforge/advancements/recipes/betterendforge/flavolite_bricks_slab_from_flavolite_bricks_stonecutting.json
+++ b/src/generated/resources/data/betterendforge/advancements/recipes/betterendforge/flavolite_bricks_slab_from_flavolite_bricks_stonecutting.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "betterendforge:flavolite_bricks_slab_from_flavolite_bricks_stonecutting"
+    ]
+  },
+  "criteria": {
+    "has_bricks": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "betterendforge:flavolite_bricks"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "betterendforge:flavolite_bricks_slab_from_flavolite_bricks_stonecutting"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_bricks",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/generated/resources/data/betterendforge/advancements/recipes/betterendforge/flavolite_bricks_slab_from_flavolite_stonecutting.json
+++ b/src/generated/resources/data/betterendforge/advancements/recipes/betterendforge/flavolite_bricks_slab_from_flavolite_stonecutting.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "betterendforge:flavolite_bricks_slab_from_flavolite_stonecutting"
+    ]
+  },
+  "criteria": {
+    "has_stone": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "betterendforge:flavolite"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "betterendforge:flavolite_bricks_slab_from_flavolite_stonecutting"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_stone",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/generated/resources/data/betterendforge/advancements/recipes/betterendforge/flavolite_bricks_stairs_from_flavolite_bricks_stonecutting.json
+++ b/src/generated/resources/data/betterendforge/advancements/recipes/betterendforge/flavolite_bricks_stairs_from_flavolite_bricks_stonecutting.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "betterendforge:flavolite_bricks_stairs_from_flavolite_bricks_stonecutting"
+    ]
+  },
+  "criteria": {
+    "has_bricks": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "betterendforge:flavolite_bricks"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "betterendforge:flavolite_bricks_stairs_from_flavolite_bricks_stonecutting"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_bricks",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/generated/resources/data/betterendforge/advancements/recipes/betterendforge/flavolite_bricks_stairs_from_flavolite_stonecutting.json
+++ b/src/generated/resources/data/betterendforge/advancements/recipes/betterendforge/flavolite_bricks_stairs_from_flavolite_stonecutting.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "betterendforge:flavolite_bricks_stairs_from_flavolite_stonecutting"
+    ]
+  },
+  "criteria": {
+    "has_stone": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "betterendforge:flavolite"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "betterendforge:flavolite_bricks_stairs_from_flavolite_stonecutting"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_stone",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/generated/resources/data/betterendforge/advancements/recipes/betterendforge/flavolite_bricks_wall_from_flavolite_bricks_stonecutting.json
+++ b/src/generated/resources/data/betterendforge/advancements/recipes/betterendforge/flavolite_bricks_wall_from_flavolite_bricks_stonecutting.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "betterendforge:flavolite_bricks_wall_from_flavolite_bricks_stonecutting"
+    ]
+  },
+  "criteria": {
+    "has_bricks": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "betterendforge:flavolite_bricks"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "betterendforge:flavolite_bricks_wall_from_flavolite_bricks_stonecutting"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_bricks",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/generated/resources/data/betterendforge/advancements/recipes/betterendforge/flavolite_bricks_wall_from_flavolite_stonecutting.json
+++ b/src/generated/resources/data/betterendforge/advancements/recipes/betterendforge/flavolite_bricks_wall_from_flavolite_stonecutting.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "betterendforge:flavolite_bricks_wall_from_flavolite_stonecutting"
+    ]
+  },
+  "criteria": {
+    "has_stone": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "betterendforge:flavolite"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "betterendforge:flavolite_bricks_wall_from_flavolite_stonecutting"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_stone",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/generated/resources/data/betterendforge/advancements/recipes/betterendforge/flavolite_button_from_flavolite_stonecutting.json
+++ b/src/generated/resources/data/betterendforge/advancements/recipes/betterendforge/flavolite_button_from_flavolite_stonecutting.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "betterendforge:flavolite_button_from_flavolite_stonecutting"
+    ]
+  },
+  "criteria": {
+    "has_stone": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "betterendforge:flavolite"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "betterendforge:flavolite_button_from_flavolite_stonecutting"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_stone",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/generated/resources/data/betterendforge/advancements/recipes/betterendforge/flavolite_pillar_from_flavolite_stonecutting.json
+++ b/src/generated/resources/data/betterendforge/advancements/recipes/betterendforge/flavolite_pillar_from_flavolite_stonecutting.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "betterendforge:flavolite_pillar_from_flavolite_stonecutting"
+    ]
+  },
+  "criteria": {
+    "has_stone": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "betterendforge:flavolite"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "betterendforge:flavolite_pillar_from_flavolite_stonecutting"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_stone",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/generated/resources/data/betterendforge/advancements/recipes/betterendforge/flavolite_polished_from_flavolite_stonecutting.json
+++ b/src/generated/resources/data/betterendforge/advancements/recipes/betterendforge/flavolite_polished_from_flavolite_stonecutting.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "betterendforge:flavolite_polished_from_flavolite_stonecutting"
+    ]
+  },
+  "criteria": {
+    "has_stone": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "betterendforge:flavolite"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "betterendforge:flavolite_polished_from_flavolite_stonecutting"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_stone",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/generated/resources/data/betterendforge/advancements/recipes/betterendforge/flavolite_slab_from_flavolite_stonecutting.json
+++ b/src/generated/resources/data/betterendforge/advancements/recipes/betterendforge/flavolite_slab_from_flavolite_stonecutting.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "betterendforge:flavolite_slab_from_flavolite_stonecutting"
+    ]
+  },
+  "criteria": {
+    "has_stone": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "betterendforge:flavolite"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "betterendforge:flavolite_slab_from_flavolite_stonecutting"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_stone",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/generated/resources/data/betterendforge/advancements/recipes/betterendforge/flavolite_stairs_from_flavolite_stonecutting.json
+++ b/src/generated/resources/data/betterendforge/advancements/recipes/betterendforge/flavolite_stairs_from_flavolite_stonecutting.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "betterendforge:flavolite_stairs_from_flavolite_stonecutting"
+    ]
+  },
+  "criteria": {
+    "has_stone": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "betterendforge:flavolite"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "betterendforge:flavolite_stairs_from_flavolite_stonecutting"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_stone",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/generated/resources/data/betterendforge/advancements/recipes/betterendforge/flavolite_tiles_from_flavolite_stonecutting.json
+++ b/src/generated/resources/data/betterendforge/advancements/recipes/betterendforge/flavolite_tiles_from_flavolite_stonecutting.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "betterendforge:flavolite_tiles_from_flavolite_stonecutting"
+    ]
+  },
+  "criteria": {
+    "has_stone": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "betterendforge:flavolite"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "betterendforge:flavolite_tiles_from_flavolite_stonecutting"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_stone",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/generated/resources/data/betterendforge/advancements/recipes/betterendforge/flavolite_wall_from_flavolite_stonecutting.json
+++ b/src/generated/resources/data/betterendforge/advancements/recipes/betterendforge/flavolite_wall_from_flavolite_stonecutting.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "betterendforge:flavolite_wall_from_flavolite_stonecutting"
+    ]
+  },
+  "criteria": {
+    "has_stone": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "betterendforge:flavolite"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "betterendforge:flavolite_wall_from_flavolite_stonecutting"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_stone",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/generated/resources/data/betterendforge/advancements/recipes/betterendforge/sulphuric_rock_bricks_from_sulphuric_rock_stonecutting.json
+++ b/src/generated/resources/data/betterendforge/advancements/recipes/betterendforge/sulphuric_rock_bricks_from_sulphuric_rock_stonecutting.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "betterendforge:sulphuric_rock_bricks_from_sulphuric_rock_stonecutting"
+    ]
+  },
+  "criteria": {
+    "has_stone": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "betterendforge:sulphuric_rock"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "betterendforge:sulphuric_rock_bricks_from_sulphuric_rock_stonecutting"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_stone",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/generated/resources/data/betterendforge/advancements/recipes/betterendforge/sulphuric_rock_bricks_slab_from_sulphuric_rock_bricks_stonecutting.json
+++ b/src/generated/resources/data/betterendforge/advancements/recipes/betterendforge/sulphuric_rock_bricks_slab_from_sulphuric_rock_bricks_stonecutting.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "betterendforge:sulphuric_rock_bricks_slab_from_sulphuric_rock_bricks_stonecutting"
+    ]
+  },
+  "criteria": {
+    "has_bricks": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "betterendforge:sulphuric_rock_bricks"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "betterendforge:sulphuric_rock_bricks_slab_from_sulphuric_rock_bricks_stonecutting"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_bricks",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/generated/resources/data/betterendforge/advancements/recipes/betterendforge/sulphuric_rock_bricks_slab_from_sulphuric_rock_stonecutting.json
+++ b/src/generated/resources/data/betterendforge/advancements/recipes/betterendforge/sulphuric_rock_bricks_slab_from_sulphuric_rock_stonecutting.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "betterendforge:sulphuric_rock_bricks_slab_from_sulphuric_rock_stonecutting"
+    ]
+  },
+  "criteria": {
+    "has_stone": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "betterendforge:sulphuric_rock"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "betterendforge:sulphuric_rock_bricks_slab_from_sulphuric_rock_stonecutting"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_stone",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/generated/resources/data/betterendforge/advancements/recipes/betterendforge/sulphuric_rock_bricks_stairs_from_sulphuric_rock_bricks_stonecutting.json
+++ b/src/generated/resources/data/betterendforge/advancements/recipes/betterendforge/sulphuric_rock_bricks_stairs_from_sulphuric_rock_bricks_stonecutting.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "betterendforge:sulphuric_rock_bricks_stairs_from_sulphuric_rock_bricks_stonecutting"
+    ]
+  },
+  "criteria": {
+    "has_bricks": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "betterendforge:sulphuric_rock_bricks"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "betterendforge:sulphuric_rock_bricks_stairs_from_sulphuric_rock_bricks_stonecutting"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_bricks",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/generated/resources/data/betterendforge/advancements/recipes/betterendforge/sulphuric_rock_bricks_stairs_from_sulphuric_rock_stonecutting.json
+++ b/src/generated/resources/data/betterendforge/advancements/recipes/betterendforge/sulphuric_rock_bricks_stairs_from_sulphuric_rock_stonecutting.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "betterendforge:sulphuric_rock_bricks_stairs_from_sulphuric_rock_stonecutting"
+    ]
+  },
+  "criteria": {
+    "has_stone": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "betterendforge:sulphuric_rock"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "betterendforge:sulphuric_rock_bricks_stairs_from_sulphuric_rock_stonecutting"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_stone",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/generated/resources/data/betterendforge/advancements/recipes/betterendforge/sulphuric_rock_bricks_wall_from_sulphuric_rock_bricks_stonecutting.json
+++ b/src/generated/resources/data/betterendforge/advancements/recipes/betterendforge/sulphuric_rock_bricks_wall_from_sulphuric_rock_bricks_stonecutting.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "betterendforge:sulphuric_rock_bricks_wall_from_sulphuric_rock_bricks_stonecutting"
+    ]
+  },
+  "criteria": {
+    "has_bricks": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "betterendforge:sulphuric_rock_bricks"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "betterendforge:sulphuric_rock_bricks_wall_from_sulphuric_rock_bricks_stonecutting"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_bricks",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/generated/resources/data/betterendforge/advancements/recipes/betterendforge/sulphuric_rock_bricks_wall_from_sulphuric_rock_stonecutting.json
+++ b/src/generated/resources/data/betterendforge/advancements/recipes/betterendforge/sulphuric_rock_bricks_wall_from_sulphuric_rock_stonecutting.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "betterendforge:sulphuric_rock_bricks_wall_from_sulphuric_rock_stonecutting"
+    ]
+  },
+  "criteria": {
+    "has_stone": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "betterendforge:sulphuric_rock"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "betterendforge:sulphuric_rock_bricks_wall_from_sulphuric_rock_stonecutting"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_stone",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/generated/resources/data/betterendforge/advancements/recipes/betterendforge/sulphuric_rock_button_from_sulphuric_rock_stonecutting.json
+++ b/src/generated/resources/data/betterendforge/advancements/recipes/betterendforge/sulphuric_rock_button_from_sulphuric_rock_stonecutting.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "betterendforge:sulphuric_rock_button_from_sulphuric_rock_stonecutting"
+    ]
+  },
+  "criteria": {
+    "has_stone": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "betterendforge:sulphuric_rock"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "betterendforge:sulphuric_rock_button_from_sulphuric_rock_stonecutting"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_stone",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/generated/resources/data/betterendforge/advancements/recipes/betterendforge/sulphuric_rock_pillar_from_sulphuric_rock_stonecutting.json
+++ b/src/generated/resources/data/betterendforge/advancements/recipes/betterendforge/sulphuric_rock_pillar_from_sulphuric_rock_stonecutting.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "betterendforge:sulphuric_rock_pillar_from_sulphuric_rock_stonecutting"
+    ]
+  },
+  "criteria": {
+    "has_stone": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "betterendforge:sulphuric_rock"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "betterendforge:sulphuric_rock_pillar_from_sulphuric_rock_stonecutting"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_stone",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/generated/resources/data/betterendforge/advancements/recipes/betterendforge/sulphuric_rock_polished_from_sulphuric_rock_stonecutting.json
+++ b/src/generated/resources/data/betterendforge/advancements/recipes/betterendforge/sulphuric_rock_polished_from_sulphuric_rock_stonecutting.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "betterendforge:sulphuric_rock_polished_from_sulphuric_rock_stonecutting"
+    ]
+  },
+  "criteria": {
+    "has_stone": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "betterendforge:sulphuric_rock"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "betterendforge:sulphuric_rock_polished_from_sulphuric_rock_stonecutting"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_stone",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/generated/resources/data/betterendforge/advancements/recipes/betterendforge/sulphuric_rock_slab_from_sulphuric_rock_stonecutting.json
+++ b/src/generated/resources/data/betterendforge/advancements/recipes/betterendforge/sulphuric_rock_slab_from_sulphuric_rock_stonecutting.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "betterendforge:sulphuric_rock_slab_from_sulphuric_rock_stonecutting"
+    ]
+  },
+  "criteria": {
+    "has_stone": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "betterendforge:sulphuric_rock"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "betterendforge:sulphuric_rock_slab_from_sulphuric_rock_stonecutting"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_stone",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/generated/resources/data/betterendforge/advancements/recipes/betterendforge/sulphuric_rock_stairs_from_sulphuric_rock_stonecutting.json
+++ b/src/generated/resources/data/betterendforge/advancements/recipes/betterendforge/sulphuric_rock_stairs_from_sulphuric_rock_stonecutting.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "betterendforge:sulphuric_rock_stairs_from_sulphuric_rock_stonecutting"
+    ]
+  },
+  "criteria": {
+    "has_stone": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "betterendforge:sulphuric_rock"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "betterendforge:sulphuric_rock_stairs_from_sulphuric_rock_stonecutting"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_stone",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/generated/resources/data/betterendforge/advancements/recipes/betterendforge/sulphuric_rock_tiles_from_sulphuric_rock_stonecutting.json
+++ b/src/generated/resources/data/betterendforge/advancements/recipes/betterendforge/sulphuric_rock_tiles_from_sulphuric_rock_stonecutting.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "betterendforge:sulphuric_rock_tiles_from_sulphuric_rock_stonecutting"
+    ]
+  },
+  "criteria": {
+    "has_stone": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "betterendforge:sulphuric_rock"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "betterendforge:sulphuric_rock_tiles_from_sulphuric_rock_stonecutting"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_stone",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/generated/resources/data/betterendforge/advancements/recipes/betterendforge/sulphuric_rock_wall_from_sulphuric_rock_stonecutting.json
+++ b/src/generated/resources/data/betterendforge/advancements/recipes/betterendforge/sulphuric_rock_wall_from_sulphuric_rock_stonecutting.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "betterendforge:sulphuric_rock_wall_from_sulphuric_rock_stonecutting"
+    ]
+  },
+  "criteria": {
+    "has_stone": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "betterendforge:sulphuric_rock"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "betterendforge:sulphuric_rock_wall_from_sulphuric_rock_stonecutting"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_stone",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/generated/resources/data/betterendforge/advancements/recipes/betterendforge/violecite_bricks_from_violecite_stonecutting.json
+++ b/src/generated/resources/data/betterendforge/advancements/recipes/betterendforge/violecite_bricks_from_violecite_stonecutting.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "betterendforge:violecite_bricks_from_violecite_stonecutting"
+    ]
+  },
+  "criteria": {
+    "has_stone": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "betterendforge:violecite"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "betterendforge:violecite_bricks_from_violecite_stonecutting"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_stone",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/generated/resources/data/betterendforge/advancements/recipes/betterendforge/violecite_bricks_slab_from_violecite_bricks_stonecutting.json
+++ b/src/generated/resources/data/betterendforge/advancements/recipes/betterendforge/violecite_bricks_slab_from_violecite_bricks_stonecutting.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "betterendforge:violecite_bricks_slab_from_violecite_bricks_stonecutting"
+    ]
+  },
+  "criteria": {
+    "has_bricks": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "betterendforge:violecite_bricks"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "betterendforge:violecite_bricks_slab_from_violecite_bricks_stonecutting"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_bricks",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/generated/resources/data/betterendforge/advancements/recipes/betterendforge/violecite_bricks_slab_from_violecite_stonecutting.json
+++ b/src/generated/resources/data/betterendforge/advancements/recipes/betterendforge/violecite_bricks_slab_from_violecite_stonecutting.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "betterendforge:violecite_bricks_slab_from_violecite_stonecutting"
+    ]
+  },
+  "criteria": {
+    "has_stone": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "betterendforge:violecite"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "betterendforge:violecite_bricks_slab_from_violecite_stonecutting"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_stone",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/generated/resources/data/betterendforge/advancements/recipes/betterendforge/violecite_bricks_stairs_from_violecite_bricks_stonecutting.json
+++ b/src/generated/resources/data/betterendforge/advancements/recipes/betterendforge/violecite_bricks_stairs_from_violecite_bricks_stonecutting.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "betterendforge:violecite_bricks_stairs_from_violecite_bricks_stonecutting"
+    ]
+  },
+  "criteria": {
+    "has_bricks": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "betterendforge:violecite_bricks"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "betterendforge:violecite_bricks_stairs_from_violecite_bricks_stonecutting"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_bricks",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/generated/resources/data/betterendforge/advancements/recipes/betterendforge/violecite_bricks_stairs_from_violecite_stonecutting.json
+++ b/src/generated/resources/data/betterendforge/advancements/recipes/betterendforge/violecite_bricks_stairs_from_violecite_stonecutting.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "betterendforge:violecite_bricks_stairs_from_violecite_stonecutting"
+    ]
+  },
+  "criteria": {
+    "has_stone": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "betterendforge:violecite"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "betterendforge:violecite_bricks_stairs_from_violecite_stonecutting"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_stone",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/generated/resources/data/betterendforge/advancements/recipes/betterendforge/violecite_bricks_wall_from_violecite_bricks_stonecutting.json
+++ b/src/generated/resources/data/betterendforge/advancements/recipes/betterendforge/violecite_bricks_wall_from_violecite_bricks_stonecutting.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "betterendforge:violecite_bricks_wall_from_violecite_bricks_stonecutting"
+    ]
+  },
+  "criteria": {
+    "has_bricks": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "betterendforge:violecite_bricks"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "betterendforge:violecite_bricks_wall_from_violecite_bricks_stonecutting"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_bricks",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/generated/resources/data/betterendforge/advancements/recipes/betterendforge/violecite_bricks_wall_from_violecite_stonecutting.json
+++ b/src/generated/resources/data/betterendforge/advancements/recipes/betterendforge/violecite_bricks_wall_from_violecite_stonecutting.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "betterendforge:violecite_bricks_wall_from_violecite_stonecutting"
+    ]
+  },
+  "criteria": {
+    "has_stone": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "betterendforge:violecite"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "betterendforge:violecite_bricks_wall_from_violecite_stonecutting"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_stone",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/generated/resources/data/betterendforge/advancements/recipes/betterendforge/violecite_button_from_violecite_stonecutting.json
+++ b/src/generated/resources/data/betterendforge/advancements/recipes/betterendforge/violecite_button_from_violecite_stonecutting.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "betterendforge:violecite_button_from_violecite_stonecutting"
+    ]
+  },
+  "criteria": {
+    "has_stone": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "betterendforge:violecite"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "betterendforge:violecite_button_from_violecite_stonecutting"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_stone",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/generated/resources/data/betterendforge/advancements/recipes/betterendforge/violecite_pillar_from_violecite_stonecutting.json
+++ b/src/generated/resources/data/betterendforge/advancements/recipes/betterendforge/violecite_pillar_from_violecite_stonecutting.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "betterendforge:violecite_pillar_from_violecite_stonecutting"
+    ]
+  },
+  "criteria": {
+    "has_stone": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "betterendforge:violecite"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "betterendforge:violecite_pillar_from_violecite_stonecutting"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_stone",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/generated/resources/data/betterendforge/advancements/recipes/betterendforge/violecite_polished_from_violecite_stonecutting.json
+++ b/src/generated/resources/data/betterendforge/advancements/recipes/betterendforge/violecite_polished_from_violecite_stonecutting.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "betterendforge:violecite_polished_from_violecite_stonecutting"
+    ]
+  },
+  "criteria": {
+    "has_stone": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "betterendforge:violecite"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "betterendforge:violecite_polished_from_violecite_stonecutting"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_stone",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/generated/resources/data/betterendforge/advancements/recipes/betterendforge/violecite_slab_from_violecite_stonecutting.json
+++ b/src/generated/resources/data/betterendforge/advancements/recipes/betterendforge/violecite_slab_from_violecite_stonecutting.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "betterendforge:violecite_slab_from_violecite_stonecutting"
+    ]
+  },
+  "criteria": {
+    "has_stone": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "betterendforge:violecite"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "betterendforge:violecite_slab_from_violecite_stonecutting"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_stone",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/generated/resources/data/betterendforge/advancements/recipes/betterendforge/violecite_stairs_from_violecite_stonecutting.json
+++ b/src/generated/resources/data/betterendforge/advancements/recipes/betterendforge/violecite_stairs_from_violecite_stonecutting.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "betterendforge:violecite_stairs_from_violecite_stonecutting"
+    ]
+  },
+  "criteria": {
+    "has_stone": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "betterendforge:violecite"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "betterendforge:violecite_stairs_from_violecite_stonecutting"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_stone",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/generated/resources/data/betterendforge/advancements/recipes/betterendforge/violecite_tiles_from_violecite_stonecutting.json
+++ b/src/generated/resources/data/betterendforge/advancements/recipes/betterendforge/violecite_tiles_from_violecite_stonecutting.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "betterendforge:violecite_tiles_from_violecite_stonecutting"
+    ]
+  },
+  "criteria": {
+    "has_stone": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "betterendforge:violecite"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "betterendforge:violecite_tiles_from_violecite_stonecutting"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_stone",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/generated/resources/data/betterendforge/advancements/recipes/betterendforge/violecite_wall_from_violecite_stonecutting.json
+++ b/src/generated/resources/data/betterendforge/advancements/recipes/betterendforge/violecite_wall_from_violecite_stonecutting.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "betterendforge:violecite_wall_from_violecite_stonecutting"
+    ]
+  },
+  "criteria": {
+    "has_stone": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "betterendforge:violecite"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "betterendforge:violecite_wall_from_violecite_stonecutting"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_stone",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/generated/resources/data/betterendforge/recipes/flavolite_bricks_from_flavolite_stonecutting.json
+++ b/src/generated/resources/data/betterendforge/recipes/flavolite_bricks_from_flavolite_stonecutting.json
@@ -1,0 +1,8 @@
+{
+  "type": "minecraft:stonecutting",
+  "ingredient": {
+    "item": "betterendforge:flavolite"
+  },
+  "result": "betterendforge:flavolite_bricks",
+  "count": 1
+}

--- a/src/generated/resources/data/betterendforge/recipes/flavolite_bricks_slab_from_flavolite_bricks_stonecutting.json
+++ b/src/generated/resources/data/betterendforge/recipes/flavolite_bricks_slab_from_flavolite_bricks_stonecutting.json
@@ -1,0 +1,8 @@
+{
+  "type": "minecraft:stonecutting",
+  "ingredient": {
+    "item": "betterendforge:flavolite_bricks"
+  },
+  "result": "betterendforge:flavolite_bricks_slab",
+  "count": 2
+}

--- a/src/generated/resources/data/betterendforge/recipes/flavolite_bricks_slab_from_flavolite_stonecutting.json
+++ b/src/generated/resources/data/betterendforge/recipes/flavolite_bricks_slab_from_flavolite_stonecutting.json
@@ -1,0 +1,8 @@
+{
+  "type": "minecraft:stonecutting",
+  "ingredient": {
+    "item": "betterendforge:flavolite"
+  },
+  "result": "betterendforge:flavolite_bricks_slab",
+  "count": 2
+}

--- a/src/generated/resources/data/betterendforge/recipes/flavolite_bricks_stairs_from_flavolite_bricks_stonecutting.json
+++ b/src/generated/resources/data/betterendforge/recipes/flavolite_bricks_stairs_from_flavolite_bricks_stonecutting.json
@@ -1,0 +1,8 @@
+{
+  "type": "minecraft:stonecutting",
+  "ingredient": {
+    "item": "betterendforge:flavolite_bricks"
+  },
+  "result": "betterendforge:flavolite_bricks_stairs",
+  "count": 1
+}

--- a/src/generated/resources/data/betterendforge/recipes/flavolite_bricks_stairs_from_flavolite_stonecutting.json
+++ b/src/generated/resources/data/betterendforge/recipes/flavolite_bricks_stairs_from_flavolite_stonecutting.json
@@ -1,0 +1,8 @@
+{
+  "type": "minecraft:stonecutting",
+  "ingredient": {
+    "item": "betterendforge:flavolite"
+  },
+  "result": "betterendforge:flavolite_bricks_stairs",
+  "count": 1
+}

--- a/src/generated/resources/data/betterendforge/recipes/flavolite_bricks_wall_from_flavolite_bricks_stonecutting.json
+++ b/src/generated/resources/data/betterendforge/recipes/flavolite_bricks_wall_from_flavolite_bricks_stonecutting.json
@@ -1,0 +1,8 @@
+{
+  "type": "minecraft:stonecutting",
+  "ingredient": {
+    "item": "betterendforge:flavolite_bricks"
+  },
+  "result": "betterendforge:flavolite_bricks_wall",
+  "count": 1
+}

--- a/src/generated/resources/data/betterendforge/recipes/flavolite_bricks_wall_from_flavolite_stonecutting.json
+++ b/src/generated/resources/data/betterendforge/recipes/flavolite_bricks_wall_from_flavolite_stonecutting.json
@@ -1,0 +1,8 @@
+{
+  "type": "minecraft:stonecutting",
+  "ingredient": {
+    "item": "betterendforge:flavolite"
+  },
+  "result": "betterendforge:flavolite_bricks_wall",
+  "count": 1
+}

--- a/src/generated/resources/data/betterendforge/recipes/flavolite_button_from_flavolite_stonecutting.json
+++ b/src/generated/resources/data/betterendforge/recipes/flavolite_button_from_flavolite_stonecutting.json
@@ -1,0 +1,8 @@
+{
+  "type": "minecraft:stonecutting",
+  "ingredient": {
+    "item": "betterendforge:flavolite"
+  },
+  "result": "betterendforge:flavolite_button",
+  "count": 1
+}

--- a/src/generated/resources/data/betterendforge/recipes/flavolite_pillar_from_flavolite_stonecutting.json
+++ b/src/generated/resources/data/betterendforge/recipes/flavolite_pillar_from_flavolite_stonecutting.json
@@ -1,0 +1,8 @@
+{
+  "type": "minecraft:stonecutting",
+  "ingredient": {
+    "item": "betterendforge:flavolite"
+  },
+  "result": "betterendforge:flavolite_pillar",
+  "count": 1
+}

--- a/src/generated/resources/data/betterendforge/recipes/flavolite_polished_from_flavolite_stonecutting.json
+++ b/src/generated/resources/data/betterendforge/recipes/flavolite_polished_from_flavolite_stonecutting.json
@@ -1,0 +1,8 @@
+{
+  "type": "minecraft:stonecutting",
+  "ingredient": {
+    "item": "betterendforge:flavolite"
+  },
+  "result": "betterendforge:flavolite_polished",
+  "count": 1
+}

--- a/src/generated/resources/data/betterendforge/recipes/flavolite_slab_from_flavolite_stonecutting.json
+++ b/src/generated/resources/data/betterendforge/recipes/flavolite_slab_from_flavolite_stonecutting.json
@@ -1,0 +1,8 @@
+{
+  "type": "minecraft:stonecutting",
+  "ingredient": {
+    "item": "betterendforge:flavolite"
+  },
+  "result": "betterendforge:flavolite_slab",
+  "count": 2
+}

--- a/src/generated/resources/data/betterendforge/recipes/flavolite_stairs_from_flavolite_stonecutting.json
+++ b/src/generated/resources/data/betterendforge/recipes/flavolite_stairs_from_flavolite_stonecutting.json
@@ -1,0 +1,8 @@
+{
+  "type": "minecraft:stonecutting",
+  "ingredient": {
+    "item": "betterendforge:flavolite"
+  },
+  "result": "betterendforge:flavolite_stairs",
+  "count": 1
+}

--- a/src/generated/resources/data/betterendforge/recipes/flavolite_tiles_from_flavolite_stonecutting.json
+++ b/src/generated/resources/data/betterendforge/recipes/flavolite_tiles_from_flavolite_stonecutting.json
@@ -1,0 +1,8 @@
+{
+  "type": "minecraft:stonecutting",
+  "ingredient": {
+    "item": "betterendforge:flavolite"
+  },
+  "result": "betterendforge:flavolite_tiles",
+  "count": 1
+}

--- a/src/generated/resources/data/betterendforge/recipes/flavolite_wall_from_flavolite_stonecutting.json
+++ b/src/generated/resources/data/betterendforge/recipes/flavolite_wall_from_flavolite_stonecutting.json
@@ -1,0 +1,8 @@
+{
+  "type": "minecraft:stonecutting",
+  "ingredient": {
+    "item": "betterendforge:flavolite"
+  },
+  "result": "betterendforge:flavolite_wall",
+  "count": 1
+}

--- a/src/generated/resources/data/betterendforge/recipes/sulphuric_rock_bricks_from_sulphuric_rock_stonecutting.json
+++ b/src/generated/resources/data/betterendforge/recipes/sulphuric_rock_bricks_from_sulphuric_rock_stonecutting.json
@@ -1,0 +1,8 @@
+{
+  "type": "minecraft:stonecutting",
+  "ingredient": {
+    "item": "betterendforge:sulphuric_rock"
+  },
+  "result": "betterendforge:sulphuric_rock_bricks",
+  "count": 1
+}

--- a/src/generated/resources/data/betterendforge/recipes/sulphuric_rock_bricks_slab_from_sulphuric_rock_bricks_stonecutting.json
+++ b/src/generated/resources/data/betterendforge/recipes/sulphuric_rock_bricks_slab_from_sulphuric_rock_bricks_stonecutting.json
@@ -1,0 +1,8 @@
+{
+  "type": "minecraft:stonecutting",
+  "ingredient": {
+    "item": "betterendforge:sulphuric_rock_bricks"
+  },
+  "result": "betterendforge:sulphuric_rock_bricks_slab",
+  "count": 2
+}

--- a/src/generated/resources/data/betterendforge/recipes/sulphuric_rock_bricks_slab_from_sulphuric_rock_stonecutting.json
+++ b/src/generated/resources/data/betterendforge/recipes/sulphuric_rock_bricks_slab_from_sulphuric_rock_stonecutting.json
@@ -1,0 +1,8 @@
+{
+  "type": "minecraft:stonecutting",
+  "ingredient": {
+    "item": "betterendforge:sulphuric_rock"
+  },
+  "result": "betterendforge:sulphuric_rock_bricks_slab",
+  "count": 2
+}

--- a/src/generated/resources/data/betterendforge/recipes/sulphuric_rock_bricks_stairs_from_sulphuric_rock_bricks_stonecutting.json
+++ b/src/generated/resources/data/betterendforge/recipes/sulphuric_rock_bricks_stairs_from_sulphuric_rock_bricks_stonecutting.json
@@ -1,0 +1,8 @@
+{
+  "type": "minecraft:stonecutting",
+  "ingredient": {
+    "item": "betterendforge:sulphuric_rock_bricks"
+  },
+  "result": "betterendforge:sulphuric_rock_bricks_stairs",
+  "count": 1
+}

--- a/src/generated/resources/data/betterendforge/recipes/sulphuric_rock_bricks_stairs_from_sulphuric_rock_stonecutting.json
+++ b/src/generated/resources/data/betterendforge/recipes/sulphuric_rock_bricks_stairs_from_sulphuric_rock_stonecutting.json
@@ -1,0 +1,8 @@
+{
+  "type": "minecraft:stonecutting",
+  "ingredient": {
+    "item": "betterendforge:sulphuric_rock"
+  },
+  "result": "betterendforge:sulphuric_rock_bricks_stairs",
+  "count": 1
+}

--- a/src/generated/resources/data/betterendforge/recipes/sulphuric_rock_bricks_wall_from_sulphuric_rock_bricks_stonecutting.json
+++ b/src/generated/resources/data/betterendforge/recipes/sulphuric_rock_bricks_wall_from_sulphuric_rock_bricks_stonecutting.json
@@ -1,0 +1,8 @@
+{
+  "type": "minecraft:stonecutting",
+  "ingredient": {
+    "item": "betterendforge:sulphuric_rock_bricks"
+  },
+  "result": "betterendforge:sulphuric_rock_bricks_wall",
+  "count": 1
+}

--- a/src/generated/resources/data/betterendforge/recipes/sulphuric_rock_bricks_wall_from_sulphuric_rock_stonecutting.json
+++ b/src/generated/resources/data/betterendforge/recipes/sulphuric_rock_bricks_wall_from_sulphuric_rock_stonecutting.json
@@ -1,0 +1,8 @@
+{
+  "type": "minecraft:stonecutting",
+  "ingredient": {
+    "item": "betterendforge:sulphuric_rock"
+  },
+  "result": "betterendforge:sulphuric_rock_bricks_wall",
+  "count": 1
+}

--- a/src/generated/resources/data/betterendforge/recipes/sulphuric_rock_button_from_sulphuric_rock_stonecutting.json
+++ b/src/generated/resources/data/betterendforge/recipes/sulphuric_rock_button_from_sulphuric_rock_stonecutting.json
@@ -1,0 +1,8 @@
+{
+  "type": "minecraft:stonecutting",
+  "ingredient": {
+    "item": "betterendforge:sulphuric_rock"
+  },
+  "result": "betterendforge:sulphuric_rock_button",
+  "count": 1
+}

--- a/src/generated/resources/data/betterendforge/recipes/sulphuric_rock_pillar_from_sulphuric_rock_stonecutting.json
+++ b/src/generated/resources/data/betterendforge/recipes/sulphuric_rock_pillar_from_sulphuric_rock_stonecutting.json
@@ -1,0 +1,8 @@
+{
+  "type": "minecraft:stonecutting",
+  "ingredient": {
+    "item": "betterendforge:sulphuric_rock"
+  },
+  "result": "betterendforge:sulphuric_rock_pillar",
+  "count": 1
+}

--- a/src/generated/resources/data/betterendforge/recipes/sulphuric_rock_polished_from_sulphuric_rock_stonecutting.json
+++ b/src/generated/resources/data/betterendforge/recipes/sulphuric_rock_polished_from_sulphuric_rock_stonecutting.json
@@ -1,0 +1,8 @@
+{
+  "type": "minecraft:stonecutting",
+  "ingredient": {
+    "item": "betterendforge:sulphuric_rock"
+  },
+  "result": "betterendforge:sulphuric_rock_polished",
+  "count": 1
+}

--- a/src/generated/resources/data/betterendforge/recipes/sulphuric_rock_slab_from_sulphuric_rock_stonecutting.json
+++ b/src/generated/resources/data/betterendforge/recipes/sulphuric_rock_slab_from_sulphuric_rock_stonecutting.json
@@ -1,0 +1,8 @@
+{
+  "type": "minecraft:stonecutting",
+  "ingredient": {
+    "item": "betterendforge:sulphuric_rock"
+  },
+  "result": "betterendforge:sulphuric_rock_slab",
+  "count": 2
+}

--- a/src/generated/resources/data/betterendforge/recipes/sulphuric_rock_stairs_from_sulphuric_rock_stonecutting.json
+++ b/src/generated/resources/data/betterendforge/recipes/sulphuric_rock_stairs_from_sulphuric_rock_stonecutting.json
@@ -1,0 +1,8 @@
+{
+  "type": "minecraft:stonecutting",
+  "ingredient": {
+    "item": "betterendforge:sulphuric_rock"
+  },
+  "result": "betterendforge:sulphuric_rock_stairs",
+  "count": 1
+}

--- a/src/generated/resources/data/betterendforge/recipes/sulphuric_rock_tiles_from_sulphuric_rock_stonecutting.json
+++ b/src/generated/resources/data/betterendforge/recipes/sulphuric_rock_tiles_from_sulphuric_rock_stonecutting.json
@@ -1,0 +1,8 @@
+{
+  "type": "minecraft:stonecutting",
+  "ingredient": {
+    "item": "betterendforge:sulphuric_rock"
+  },
+  "result": "betterendforge:sulphuric_rock_tiles",
+  "count": 1
+}

--- a/src/generated/resources/data/betterendforge/recipes/sulphuric_rock_wall_from_sulphuric_rock_stonecutting.json
+++ b/src/generated/resources/data/betterendforge/recipes/sulphuric_rock_wall_from_sulphuric_rock_stonecutting.json
@@ -1,0 +1,8 @@
+{
+  "type": "minecraft:stonecutting",
+  "ingredient": {
+    "item": "betterendforge:sulphuric_rock"
+  },
+  "result": "betterendforge:sulphuric_rock_wall",
+  "count": 1
+}

--- a/src/generated/resources/data/betterendforge/recipes/violecite_bricks_from_violecite_stonecutting.json
+++ b/src/generated/resources/data/betterendforge/recipes/violecite_bricks_from_violecite_stonecutting.json
@@ -1,0 +1,8 @@
+{
+  "type": "minecraft:stonecutting",
+  "ingredient": {
+    "item": "betterendforge:violecite"
+  },
+  "result": "betterendforge:violecite_bricks",
+  "count": 1
+}

--- a/src/generated/resources/data/betterendforge/recipes/violecite_bricks_slab_from_violecite_bricks_stonecutting.json
+++ b/src/generated/resources/data/betterendforge/recipes/violecite_bricks_slab_from_violecite_bricks_stonecutting.json
@@ -1,0 +1,8 @@
+{
+  "type": "minecraft:stonecutting",
+  "ingredient": {
+    "item": "betterendforge:violecite_bricks"
+  },
+  "result": "betterendforge:violecite_bricks_slab",
+  "count": 2
+}

--- a/src/generated/resources/data/betterendforge/recipes/violecite_bricks_slab_from_violecite_stonecutting.json
+++ b/src/generated/resources/data/betterendforge/recipes/violecite_bricks_slab_from_violecite_stonecutting.json
@@ -1,0 +1,8 @@
+{
+  "type": "minecraft:stonecutting",
+  "ingredient": {
+    "item": "betterendforge:violecite"
+  },
+  "result": "betterendforge:violecite_bricks_slab",
+  "count": 2
+}

--- a/src/generated/resources/data/betterendforge/recipes/violecite_bricks_stairs_from_violecite_bricks_stonecutting.json
+++ b/src/generated/resources/data/betterendforge/recipes/violecite_bricks_stairs_from_violecite_bricks_stonecutting.json
@@ -1,0 +1,8 @@
+{
+  "type": "minecraft:stonecutting",
+  "ingredient": {
+    "item": "betterendforge:violecite_bricks"
+  },
+  "result": "betterendforge:violecite_bricks_stairs",
+  "count": 1
+}

--- a/src/generated/resources/data/betterendforge/recipes/violecite_bricks_stairs_from_violecite_stonecutting.json
+++ b/src/generated/resources/data/betterendforge/recipes/violecite_bricks_stairs_from_violecite_stonecutting.json
@@ -1,0 +1,8 @@
+{
+  "type": "minecraft:stonecutting",
+  "ingredient": {
+    "item": "betterendforge:violecite"
+  },
+  "result": "betterendforge:violecite_bricks_stairs",
+  "count": 1
+}

--- a/src/generated/resources/data/betterendforge/recipes/violecite_bricks_wall_from_violecite_bricks_stonecutting.json
+++ b/src/generated/resources/data/betterendforge/recipes/violecite_bricks_wall_from_violecite_bricks_stonecutting.json
@@ -1,0 +1,8 @@
+{
+  "type": "minecraft:stonecutting",
+  "ingredient": {
+    "item": "betterendforge:violecite_bricks"
+  },
+  "result": "betterendforge:violecite_bricks_wall",
+  "count": 1
+}

--- a/src/generated/resources/data/betterendforge/recipes/violecite_bricks_wall_from_violecite_stonecutting.json
+++ b/src/generated/resources/data/betterendforge/recipes/violecite_bricks_wall_from_violecite_stonecutting.json
@@ -1,0 +1,8 @@
+{
+  "type": "minecraft:stonecutting",
+  "ingredient": {
+    "item": "betterendforge:violecite"
+  },
+  "result": "betterendforge:violecite_bricks_wall",
+  "count": 1
+}

--- a/src/generated/resources/data/betterendforge/recipes/violecite_button_from_violecite_stonecutting.json
+++ b/src/generated/resources/data/betterendforge/recipes/violecite_button_from_violecite_stonecutting.json
@@ -1,0 +1,8 @@
+{
+  "type": "minecraft:stonecutting",
+  "ingredient": {
+    "item": "betterendforge:violecite"
+  },
+  "result": "betterendforge:violecite_button",
+  "count": 1
+}

--- a/src/generated/resources/data/betterendforge/recipes/violecite_pillar_from_violecite_stonecutting.json
+++ b/src/generated/resources/data/betterendforge/recipes/violecite_pillar_from_violecite_stonecutting.json
@@ -1,0 +1,8 @@
+{
+  "type": "minecraft:stonecutting",
+  "ingredient": {
+    "item": "betterendforge:violecite"
+  },
+  "result": "betterendforge:violecite_pillar",
+  "count": 1
+}

--- a/src/generated/resources/data/betterendforge/recipes/violecite_polished_from_violecite_stonecutting.json
+++ b/src/generated/resources/data/betterendforge/recipes/violecite_polished_from_violecite_stonecutting.json
@@ -1,0 +1,8 @@
+{
+  "type": "minecraft:stonecutting",
+  "ingredient": {
+    "item": "betterendforge:violecite"
+  },
+  "result": "betterendforge:violecite_polished",
+  "count": 1
+}

--- a/src/generated/resources/data/betterendforge/recipes/violecite_slab_from_violecite_stonecutting.json
+++ b/src/generated/resources/data/betterendforge/recipes/violecite_slab_from_violecite_stonecutting.json
@@ -1,0 +1,8 @@
+{
+  "type": "minecraft:stonecutting",
+  "ingredient": {
+    "item": "betterendforge:violecite"
+  },
+  "result": "betterendforge:violecite_slab",
+  "count": 2
+}

--- a/src/generated/resources/data/betterendforge/recipes/violecite_stairs_from_violecite_stonecutting.json
+++ b/src/generated/resources/data/betterendforge/recipes/violecite_stairs_from_violecite_stonecutting.json
@@ -1,0 +1,8 @@
+{
+  "type": "minecraft:stonecutting",
+  "ingredient": {
+    "item": "betterendforge:violecite"
+  },
+  "result": "betterendforge:violecite_stairs",
+  "count": 1
+}

--- a/src/generated/resources/data/betterendforge/recipes/violecite_tiles_from_violecite_stonecutting.json
+++ b/src/generated/resources/data/betterendforge/recipes/violecite_tiles_from_violecite_stonecutting.json
@@ -1,0 +1,8 @@
+{
+  "type": "minecraft:stonecutting",
+  "ingredient": {
+    "item": "betterendforge:violecite"
+  },
+  "result": "betterendforge:violecite_tiles",
+  "count": 1
+}

--- a/src/generated/resources/data/betterendforge/recipes/violecite_wall_from_violecite_stonecutting.json
+++ b/src/generated/resources/data/betterendforge/recipes/violecite_wall_from_violecite_stonecutting.json
@@ -1,0 +1,8 @@
+{
+  "type": "minecraft:stonecutting",
+  "ingredient": {
+    "item": "betterendforge:violecite"
+  },
+  "result": "betterendforge:violecite_wall",
+  "count": 1
+}

--- a/src/main/java/mod/beethoven92/betterendforge/data/ModRecipes.java
+++ b/src/main/java/mod/beethoven92/betterendforge/data/ModRecipes.java
@@ -18,6 +18,7 @@ import net.minecraft.data.IFinishedRecipe;
 import net.minecraft.data.RecipeProvider;
 import net.minecraft.data.ShapedRecipeBuilder;
 import net.minecraft.data.ShapelessRecipeBuilder;
+import net.minecraft.data.SingleItemRecipeBuilder;
 import net.minecraft.data.SmithingRecipeBuilder;
 import net.minecraft.item.DyeColor;
 import net.minecraft.item.DyeItem;
@@ -221,6 +222,7 @@ public class ModRecipes extends RecipeProvider
 	
 	private void makeStoneMaterialRecipes(StoneMaterial material, Consumer<IFinishedRecipe> consumer)
 	{
+		// Crafting
 		ShapedRecipeBuilder.shapedRecipe(material.bricks.get(), 4).key('#', material.stone.get()).patternLine("##").patternLine("##").setGroup("end_bricks").addCriterion("has_stone", hasItem(material.stone.get())).build(consumer);
 		ShapedRecipeBuilder.shapedRecipe(material.polished.get(), 4).key('#', material.bricks.get()).patternLine("##").patternLine("##").setGroup("end_tile").addCriterion("has_bricks", hasItem(material.bricks.get())).build(consumer);
 		ShapedRecipeBuilder.shapedRecipe(material.tiles.get(), 4).key('#', material.polished.get()).patternLine("##").patternLine("##").setGroup("end_small_tile").addCriterion("has_polished_stone", hasItem(material.polished.get())).build(consumer);
@@ -236,6 +238,22 @@ public class ModRecipes extends RecipeProvider
 	    registerLantern(material.lantern.get(), material.slab.get(), consumer, material.name);
 	    registerPedestal(material.pedestal.get(), material.slab.get(), material.pillar.get(), consumer, material.name);
 	    ShapedRecipeBuilder.shapedRecipe(material.furnace.get()).key('#', material.stone.get()).patternLine("###").patternLine("# #").patternLine("###").setGroup("end_stone_furnaces").addCriterion("has_stone", hasItem(material.stone.get())).build(consumer);
+
+		// Stonecutting
+		SingleItemRecipeBuilder.stonecuttingRecipe(Ingredient.fromItems(material.stone.get()), material.bricks.get()).addCriterion("has_stone", hasItem(material.stone.get())).build(consumer, rl(material.name + "_bricks_from_" + material.name + "_stonecutting"));
+		SingleItemRecipeBuilder.stonecuttingRecipe(Ingredient.fromItems(material.stone.get()), material.polished.get()).addCriterion("has_stone", hasItem(material.stone.get())).build(consumer, rl(material.name + "_polished_from_" + material.name + "_stonecutting"));
+		SingleItemRecipeBuilder.stonecuttingRecipe(Ingredient.fromItems(material.stone.get()), material.tiles.get()).addCriterion("has_stone", hasItem(material.stone.get())).build(consumer, rl(material.name + "_tiles_from_" + material.name + "_stonecutting"));
+		SingleItemRecipeBuilder.stonecuttingRecipe(Ingredient.fromItems(material.stone.get()), material.pillar.get()).addCriterion("has_stone", hasItem(material.stone.get())).build(consumer, rl(material.name + "_pillar_from_" + material.name + "_stonecutting"));
+		SingleItemRecipeBuilder.stonecuttingRecipe(Ingredient.fromItems(material.stone.get()), material.stairs.get()).addCriterion("has_stone", hasItem(material.stone.get())).build(consumer, rl(material.name + "_stairs_from_" + material.name + "_stonecutting"));
+		SingleItemRecipeBuilder.stonecuttingRecipe(Ingredient.fromItems(material.stone.get()), material.slab.get(), 2).addCriterion("has_stone", hasItem(material.stone.get())).build(consumer, rl(material.name + "_slab_from_" + material.name + "_stonecutting"));
+		SingleItemRecipeBuilder.stonecuttingRecipe(Ingredient.fromItems(material.stone.get()), material.brick_stairs.get()).addCriterion("has_stone", hasItem(material.stone.get())).build(consumer, rl(material.name + "_bricks_stairs_from_" + material.name + "_stonecutting"));
+		SingleItemRecipeBuilder.stonecuttingRecipe(Ingredient.fromItems(material.stone.get()), material.brick_slab.get(), 2).addCriterion("has_stone", hasItem(material.stone.get())).build(consumer, rl(material.name + "_bricks_slab_from_" + material.name + "_stonecutting"));
+		SingleItemRecipeBuilder.stonecuttingRecipe(Ingredient.fromItems(material.stone.get()), material.wall.get()).addCriterion("has_stone", hasItem(material.stone.get())).build(consumer, rl(material.name + "_wall_from_" + material.name + "_stonecutting"));
+		SingleItemRecipeBuilder.stonecuttingRecipe(Ingredient.fromItems(material.stone.get()), material.brick_wall.get()).addCriterion("has_stone", hasItem(material.stone.get())).build(consumer, rl(material.name + "_bricks_wall_from_" + material.name + "_stonecutting"));
+		SingleItemRecipeBuilder.stonecuttingRecipe(Ingredient.fromItems(material.stone.get()), material.button.get()).addCriterion("has_stone", hasItem(material.stone.get())).build(consumer, rl(material.name + "_button_from_" + material.name + "_stonecutting"));
+		SingleItemRecipeBuilder.stonecuttingRecipe(Ingredient.fromItems(material.bricks.get()), material.brick_stairs.get()).addCriterion("has_bricks", hasItem(material.bricks.get())).build(consumer, rl(material.name + "_bricks_stairs_from_" + material.name + "_bricks_stonecutting"));
+		SingleItemRecipeBuilder.stonecuttingRecipe(Ingredient.fromItems(material.bricks.get()), material.brick_slab.get(), 2).addCriterion("has_bricks", hasItem(material.bricks.get())).build(consumer, rl(material.name + "_bricks_slab_from_" + material.name + "_bricks_stonecutting"));
+		SingleItemRecipeBuilder.stonecuttingRecipe(Ingredient.fromItems(material.bricks.get()), material.brick_wall.get()).addCriterion("has_bricks", hasItem(material.bricks.get())).build(consumer, rl(material.name + "_bricks_wall_from_" + material.name + "_bricks_stonecutting"));
 	}
 	
 	private void makeMetalMaterialRecipes(MetalMaterial material, Consumer<IFinishedRecipe> consumer)


### PR DESCRIPTION
This PR adds Stonecutter recipes for cutting all 11 types of derived stone blocks from each base stone block, and for cutting all 3 types of brick-specific derived blocks from each stone bricks block. It excludes pressure plates and other blocks that require more than one input block in their regular crafting recipes.