### PR TITLE
Add more Minecraft and Forge tags

### DIFF
--- a/src/generated/resources/data/forge/tags/items/mushrooms.json
+++ b/src/generated/resources/data/forge/tags/items/mushrooms.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "betterendforge:bolux_mushroom",
+    "betterendforge:chorus_mushroom_raw"
+  ]
+}

--- a/src/generated/resources/data/forge/tags/items/seeds.json
+++ b/src/generated/resources/data/forge/tags/items/seeds.json
@@ -1,0 +1,17 @@
+{
+  "replace": false,
+  "values": [
+    "betterendforge:blue_vine_seed",
+    "betterendforge:end_lily_seed",
+    "betterendforge:hydralux_sapling",
+    "betterendforge:lanceleaf_seed",
+    "betterendforge:lumecorn_seed",
+    "betterendforge:glowing_pillar_seed",
+    "betterendforge:shadow_berry",
+    "betterendforge:blossom_berry_seed",
+    "betterendforge:amber_root_seed",
+    "betterendforge:chorus_mushroom_seed",
+    "betterendforge:bulb_vine_seed",
+    "betterendforge:end_lotus_seed"
+  ]
+}

--- a/src/generated/resources/data/minecraft/tags/blocks/slabs.json
+++ b/src/generated/resources/data/minecraft/tags/blocks/slabs.json
@@ -1,6 +1,8 @@
 {
   "replace": false,
   "values": [
+    "betterendforge:dragon_bone_slab",
+    "betterendforge:neon_cactus_slab",
     "betterendforge:mossy_glowshroom_slab",
     "betterendforge:lacugrove_slab",
     "betterendforge:end_lotus_slab",

--- a/src/generated/resources/data/minecraft/tags/blocks/stairs.json
+++ b/src/generated/resources/data/minecraft/tags/blocks/stairs.json
@@ -1,6 +1,8 @@
 {
   "replace": false,
   "values": [
+    "betterendforge:dragon_bone_stairs",
+    "betterendforge:neon_cactus_stairs",
     "betterendforge:mossy_glowshroom_stairs",
     "betterendforge:lacugrove_stairs",
     "betterendforge:end_lotus_stairs",
@@ -11,6 +13,12 @@
     "betterendforge:umbrella_tree_stairs",
     "betterendforge:jellyshroom_stairs",
     "betterendforge:lucernia_stairs",
+    "betterendforge:flavolite_stairs",
+    "betterendforge:flavolite_bricks_stairs",
+    "betterendforge:violecite_stairs",
+    "betterendforge:violecite_bricks_stairs",
+    "betterendforge:sulphuric_rock_stairs",
+    "betterendforge:sulphuric_rock_bricks_stairs",
     "betterendforge:thallasium_stairs",
     "betterendforge:terminite_stairs"
   ]

--- a/src/generated/resources/data/minecraft/tags/blocks/wooden_slabs.json
+++ b/src/generated/resources/data/minecraft/tags/blocks/wooden_slabs.json
@@ -1,6 +1,7 @@
 {
   "replace": false,
   "values": [
+    "betterendforge:neon_cactus_slab",
     "betterendforge:mossy_glowshroom_slab",
     "betterendforge:lacugrove_slab",
     "betterendforge:end_lotus_slab",

--- a/src/generated/resources/data/minecraft/tags/blocks/wooden_stairs.json
+++ b/src/generated/resources/data/minecraft/tags/blocks/wooden_stairs.json
@@ -1,6 +1,7 @@
 {
   "replace": false,
   "values": [
+    "betterendforge:neon_cactus_stairs",
     "betterendforge:mossy_glowshroom_stairs",
     "betterendforge:lacugrove_stairs",
     "betterendforge:end_lotus_stairs",

--- a/src/generated/resources/data/minecraft/tags/items/beacon_payment_items.json
+++ b/src/generated/resources/data/minecraft/tags/items/beacon_payment_items.json
@@ -1,0 +1,8 @@
+{
+  "replace": false,
+  "values": [
+    "betterendforge:aeternium_ingot",
+    "betterendforge:thallasium_ingot",
+    "betterendforge:terminite_ingot"
+  ]
+}

--- a/src/generated/resources/data/minecraft/tags/items/signs.json
+++ b/src/generated/resources/data/minecraft/tags/items/signs.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "values": [
+    "betterendforge:mossy_glowshroom_sign",
+    "betterendforge:lacugrove_sign",
+    "betterendforge:end_lotus_sign",
+    "betterendforge:pythadendron_sign",
+    "betterendforge:dragon_tree_sign",
+    "betterendforge:tenanea_sign",
+    "betterendforge:helix_tree_sign",
+    "betterendforge:umbrella_tree_sign",
+    "betterendforge:jellyshroom_sign",
+    "betterendforge:lucernia_sign"
+  ]
+}

--- a/src/generated/resources/data/minecraft/tags/items/slabs.json
+++ b/src/generated/resources/data/minecraft/tags/items/slabs.json
@@ -1,6 +1,8 @@
 {
   "replace": false,
   "values": [
+    "betterendforge:dragon_bone_slab",
+    "betterendforge:neon_cactus_slab",
     "betterendforge:mossy_glowshroom_slab",
     "betterendforge:lacugrove_slab",
     "betterendforge:end_lotus_slab",

--- a/src/generated/resources/data/minecraft/tags/items/stairs.json
+++ b/src/generated/resources/data/minecraft/tags/items/stairs.json
@@ -1,6 +1,8 @@
 {
   "replace": false,
   "values": [
+    "betterendforge:dragon_bone_stairs",
+    "betterendforge:neon_cactus_stairs",
     "betterendforge:mossy_glowshroom_stairs",
     "betterendforge:lacugrove_stairs",
     "betterendforge:end_lotus_stairs",
@@ -11,6 +13,12 @@
     "betterendforge:umbrella_tree_stairs",
     "betterendforge:jellyshroom_stairs",
     "betterendforge:lucernia_stairs",
+    "betterendforge:flavolite_stairs",
+    "betterendforge:flavolite_bricks_stairs",
+    "betterendforge:violecite_stairs",
+    "betterendforge:violecite_bricks_stairs",
+    "betterendforge:sulphuric_rock_stairs",
+    "betterendforge:sulphuric_rock_bricks_stairs",
     "betterendforge:thallasium_stairs",
     "betterendforge:terminite_stairs"
   ]

--- a/src/generated/resources/data/minecraft/tags/items/walls.json
+++ b/src/generated/resources/data/minecraft/tags/items/walls.json
@@ -1,0 +1,11 @@
+{
+  "replace": false,
+  "values": [
+    "betterendforge:flavolite_wall",
+    "betterendforge:flavolite_bricks_wall",
+    "betterendforge:violecite_wall",
+    "betterendforge:violecite_bricks_wall",
+    "betterendforge:sulphuric_rock_wall",
+    "betterendforge:sulphuric_rock_bricks_wall"
+  ]
+}

--- a/src/generated/resources/data/minecraft/tags/items/wooden_slabs.json
+++ b/src/generated/resources/data/minecraft/tags/items/wooden_slabs.json
@@ -1,6 +1,7 @@
 {
   "replace": false,
   "values": [
+    "betterendforge:neon_cactus_slab",
     "betterendforge:mossy_glowshroom_slab",
     "betterendforge:lacugrove_slab",
     "betterendforge:end_lotus_slab",

--- a/src/generated/resources/data/minecraft/tags/items/wooden_stairs.json
+++ b/src/generated/resources/data/minecraft/tags/items/wooden_stairs.json
@@ -1,6 +1,7 @@
 {
   "replace": false,
   "values": [
+    "betterendforge:neon_cactus_stairs",
     "betterendforge:mossy_glowshroom_stairs",
     "betterendforge:lacugrove_stairs",
     "betterendforge:end_lotus_stairs",

--- a/src/main/java/mod/beethoven92/betterendforge/data/ModBlockTagsProvider.java
+++ b/src/main/java/mod/beethoven92/betterendforge/data/ModBlockTagsProvider.java
@@ -68,6 +68,14 @@ public class ModBlockTagsProvider extends BlockTagsProvider
 		
 		getOrCreateBuilder(BlockTags.ANVIL).add(ModBlocks.AETERNIUM_ANVIL.get());
 		
+		getOrCreateBuilder(BlockTags.SLABS).add(ModBlocks.DRAGON_BONE_SLAB.get());
+		getOrCreateBuilder(BlockTags.SLABS).add(ModBlocks.NEON_CACTUS_BLOCK_SLAB.get());
+		getOrCreateBuilder(BlockTags.WOODEN_SLABS).add(ModBlocks.NEON_CACTUS_BLOCK_SLAB.get());
+
+		getOrCreateBuilder(BlockTags.STAIRS).add(ModBlocks.DRAGON_BONE_STAIRS.get());
+		getOrCreateBuilder(BlockTags.STAIRS).add(ModBlocks.NEON_CACTUS_BLOCK_STAIRS.get());
+		getOrCreateBuilder(BlockTags.WOODEN_STAIRS).add(ModBlocks.NEON_CACTUS_BLOCK_STAIRS.get());
+		
 		// WOODEN MATERIALS
 		registerWoodenMaterialTags(ModBlocks.MOSSY_GLOWSHROOM);
 		registerWoodenMaterialTags(ModBlocks.LACUGROVE);
@@ -151,6 +159,9 @@ public class ModBlockTagsProvider extends BlockTagsProvider
 		
 		getOrCreateBuilder(BlockTags.SLABS).add(material.slab.get());
 		getOrCreateBuilder(BlockTags.SLABS).add(material.brick_slab.get());
+		
+		getOrCreateBuilder(BlockTags.STAIRS).add(material.stairs.get());
+		getOrCreateBuilder(BlockTags.STAIRS).add(material.brick_stairs.get());
 		
 		getOrCreateBuilder(BlockTags.PRESSURE_PLATES).add(material.pressure_plate.get());
 		getOrCreateBuilder(BlockTags.STONE_PRESSURE_PLATES).add(material.pressure_plate.get());

--- a/src/main/java/mod/beethoven92/betterendforge/data/ModItemTagsProvider.java
+++ b/src/main/java/mod/beethoven92/betterendforge/data/ModItemTagsProvider.java
@@ -5,7 +5,10 @@ import mod.beethoven92.betterendforge.common.block.TerrainBlock;
 import mod.beethoven92.betterendforge.common.block.material.MetalMaterial;
 import mod.beethoven92.betterendforge.common.block.material.StoneMaterial;
 import mod.beethoven92.betterendforge.common.block.material.WoodenMaterial;
+import mod.beethoven92.betterendforge.common.block.template.EndCropBlock;
 import mod.beethoven92.betterendforge.common.block.template.EndSaplingBlock;
+import mod.beethoven92.betterendforge.common.block.template.PlantBlockWithAge;
+import mod.beethoven92.betterendforge.common.block.template.UnderwaterPlantBlockWithAge;
 import mod.beethoven92.betterendforge.common.init.ModBlocks;
 import mod.beethoven92.betterendforge.common.init.ModItems;
 import mod.beethoven92.betterendforge.common.init.ModTags;
@@ -42,23 +45,42 @@ public class ModItemTagsProvider extends ItemTagsProvider
 			{
 				getOrCreateBuilder(ItemTags.SAPLINGS).add(block.asItem());
 			}
+			if (block instanceof EndCropBlock || block instanceof PlantBlockWithAge || block instanceof UnderwaterPlantBlockWithAge)
+			{
+				getOrCreateBuilder(Tags.Items.SEEDS).add(block.asItem());
+			}
 		});
 		
 		// Misc Forge tags
+		getOrCreateBuilder(Tags.Items.DUSTS).add(ModItems.ENDER_DUST.get());
+
 		getOrCreateBuilder(Tags.Items.INGOTS).add(ModItems.AETERNIUM_INGOT.get());
+		
+		getOrCreateBuilder(Tags.Items.MUSHROOMS).add(ModBlocks.BOLUX_MUSHROOM.get().asItem());
+		getOrCreateBuilder(Tags.Items.MUSHROOMS).add(ModItems.CHORUS_MUSHROOM_RAW.get());
 		
 		getOrCreateBuilder(Tags.Items.ORES).add(ModBlocks.ENDER_ORE.get().asItem());
 		getOrCreateBuilder(Tags.Items.ORES).add(ModBlocks.AMBER_ORE.get().asItem());
-
-		getOrCreateBuilder(Tags.Items.DUSTS).add(ModItems.ENDER_DUST.get());
+		
+		getOrCreateBuilder(Tags.Items.SEEDS).add(ModBlocks.END_LOTUS_SEED.get().asItem());
 		
 		getOrCreateBuilder(Tags.Items.STORAGE_BLOCKS).add(ModBlocks.AETERNIUM_BLOCK.get().asItem());
 		getOrCreateBuilder(Tags.Items.STORAGE_BLOCKS).add(ModBlocks.AMBER_BLOCK.get().asItem());
 		
 		// Misc Minecraft tags
+		getOrCreateBuilder(ItemTags.ANVIL).add(ModBlocks.AETERNIUM_ANVIL.get().asItem());
+		
+		getOrCreateBuilder(ItemTags.BEACON_PAYMENT_ITEMS).add(ModItems.AETERNIUM_INGOT.get());
+		
 		getOrCreateBuilder(ItemTags.PIGLIN_LOVED).add(ModItems.GOLDEN_HAMMER.get());
 		
-		getOrCreateBuilder(ItemTags.ANVIL).add(ModBlocks.AETERNIUM_ANVIL.get().asItem());
+		getOrCreateBuilder(ItemTags.SLABS).add(ModBlocks.DRAGON_BONE_SLAB.get().asItem());
+		getOrCreateBuilder(ItemTags.SLABS).add(ModBlocks.NEON_CACTUS_BLOCK_SLAB.get().asItem());
+		getOrCreateBuilder(ItemTags.WOODEN_SLABS).add(ModBlocks.NEON_CACTUS_BLOCK_SLAB.get().asItem());
+		
+		getOrCreateBuilder(ItemTags.STAIRS).add(ModBlocks.DRAGON_BONE_STAIRS.get().asItem());
+		getOrCreateBuilder(ItemTags.STAIRS).add(ModBlocks.NEON_CACTUS_BLOCK_STAIRS.get().asItem());
+		getOrCreateBuilder(ItemTags.WOODEN_STAIRS).add(ModBlocks.NEON_CACTUS_BLOCK_STAIRS.get().asItem());
 		
 		// Mod Tags
 		getOrCreateBuilder(ModTags.HAMMERS).add(ModItems.IRON_HAMMER.get());
@@ -122,6 +144,8 @@ public class ModItemTagsProvider extends ItemTagsProvider
 		getOrCreateBuilder(ItemTags.TRAPDOORS).add(material.trapdoor.get().asItem());
 		getOrCreateBuilder(ItemTags.WOODEN_TRAPDOORS).add(material.trapdoor.get().asItem());
 		
+		getOrCreateBuilder(ItemTags.SIGNS).add(material.sign.get().asItem());
+		
 		// Forge Tags
 		getOrCreateBuilder(Tags.Items.FENCES).add(material.fence.get().asItem());
 		getOrCreateBuilder(Tags.Items.FENCES_WOODEN).add(material.fence.get().asItem());
@@ -140,8 +164,14 @@ public class ModItemTagsProvider extends ItemTagsProvider
 	{
 		getOrCreateBuilder(ItemTags.STONE_BRICKS).add(material.bricks.get().asItem());
 		
+		getOrCreateBuilder(ItemTags.WALLS).add(material.wall.get().asItem());
+		getOrCreateBuilder(ItemTags.WALLS).add(material.brick_wall.get().asItem());
+		
 		getOrCreateBuilder(ItemTags.SLABS).add(material.slab.get().asItem());
 		getOrCreateBuilder(ItemTags.SLABS).add(material.brick_slab.get().asItem());
+		
+		getOrCreateBuilder(ItemTags.STAIRS).add(material.stairs.get().asItem());
+		getOrCreateBuilder(ItemTags.STAIRS).add(material.brick_stairs.get().asItem());
 		
 		getOrCreateBuilder(ItemTags.STONE_CRAFTING_MATERIALS).add(material.stone.get().asItem());
 		getOrCreateBuilder(ItemTags.STONE_TOOL_MATERIALS).add(material.stone.get().asItem());
@@ -164,6 +194,8 @@ public class ModItemTagsProvider extends ItemTagsProvider
 		getOrCreateBuilder(ItemTags.TRAPDOORS).add(material.trapdoor.get().asItem());
 		
 		getOrCreateBuilder(ItemTags.ANVIL).add(material.anvil.get().asItem());
+		
+		getOrCreateBuilder(ItemTags.BEACON_PAYMENT_ITEMS).add(material.ingot.get());
 		
 		// Forge Tags
 		getOrCreateBuilder(Tags.Items.NUGGETS).add(material.nugget.get());

--- a/src/main/resources/data/forge/tags/items/cooked_fishes.json
+++ b/src/main/resources/data/forge/tags/items/cooked_fishes.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "betterendforge:end_fish_cooked"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/fruits.json
+++ b/src/main/resources/data/forge/tags/items/fruits.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "betterendforge:blossom_berry",
+    "betterendforge:shadow_berry_raw"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/ice.json
+++ b/src/main/resources/data/forge/tags/items/ice.json
@@ -1,0 +1,8 @@
+{
+  "replace": false,
+  "values": [
+    "betterendforge:emerald_ice",
+    "betterendforge:dense_emerald_ice",
+    "betterendforge:ancient_emerald_ice"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/raw_fishes.json
+++ b/src/main/resources/data/forge/tags/items/raw_fishes.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "betterendforge:end_fish_raw"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/sapling.json
+++ b/src/main/resources/data/forge/tags/items/sapling.json
@@ -1,0 +1,13 @@
+{
+  "replace": false,
+  "values": [
+    "betterendforge:mossy_glowshroom_sapling",
+    "betterendforge:lacugrove_sapling",
+    "betterendforge:pythadendron_sapling",
+    "betterendforge:dragon_tree_sapling",
+    "betterendforge:tenanea_sapling",
+    "betterendforge:helix_tree_sapling",
+    "betterendforge:umbrella_tree_sapling",
+    "betterendforge:lucernia_sapling"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/vegetables.json
+++ b/src/main/resources/data/forge/tags/items/vegetables.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "betterendforge:amber_root_raw"
+  ]
+}


### PR DESCRIPTION
This PR adds a variety of tags, both base game and Forge, to blocks and items that were missing them. Some Forge tags are not listed in its official `Tags.Blocks` and `Tags.Items` classes, but are used consistently by other mods; these are added here by JSON files instead. Neon Cactus products are treated here as wood-based to match the Structurize mod's treatment of its Cactus products.