### PR TITLE
fix local varible bug in silkmoth's public void tick()

### DIFF
--- a/src/main/java/mod/beethoven92/betterendforge/common/entity/SilkMothEntity.java
+++ b/src/main/java/mod/beethoven92/betterendforge/common/entity/SilkMothEntity.java
@@ -264,6 +264,7 @@ public class SilkMothEntity extends AnimalEntity implements IFlyingAnimal {
 					    if (fullness < 3 && SilkMothEntity.this.rand.nextBoolean()) 
 					    {
 					    	fullness++;
+							state = state.with(BlockProperties.FULLNESS, fullness);
 						    BlockHelper.setWithUpdate(SilkMothEntity.this.hiveWorld, SilkMothEntity.this.hivePos, state);
 					    }
 					    SilkMothEntity.this.world.playSound(null, SilkMothEntity.this.entrance,


### PR DESCRIPTION
Fix #227 SilkMothEntity.java only add the local varible fullness